### PR TITLE
pass severity to error message template

### DIFF
--- a/routes/results.js
+++ b/routes/results.js
@@ -12,11 +12,10 @@ router.get('/', (request, response) => {
         if (queryResult.error || queryResult.itemsFound === 0) {
             console.log(`results.js error or empty: ${JSON.stringify(queryResult)}`);
             const errResponse = {
-                results: {
-                    items: []
-                },
-                qryResult: queryResult,
-                error: [queryResult.error] //TODO Can we make queryResult.error an array?
+                error: {
+                    msg: queryResult.error,
+                    severity: queryResult.severity
+                }
             };
 
             response.render('results', errResponse);

--- a/views/messages.pug
+++ b/views/messages.pug
@@ -7,10 +7,9 @@
         severity - severity to include in this block
         alertclass - alert class to apply to all messages in this section
         iconclass - icon class to apply to all messages in this section
-mixin pf-message-section(messages, severity, alertclass, iconclass)
-    each msg, sev in messages
-        if (sev == severity)
-            +pf-message(msg)(alert=['alert',alertclass], icon=['pficon', iconclass])
+mixin pf-message-section(message, severity, alertclass, iconclass)
+    if (message.severity === severity)
+        +pf-message(message.msg)(alert=['alert',alertclass], icon=['pficon', iconclass])
 
 //- pf-message: Display a single message and apply appropriate classes.
         text - message text to display
@@ -24,13 +23,13 @@ mixin pf-message(text)
 
 div(class="pm-message-area")
     //- Error
-    +pf-message-section(error, '0', 'alert-danger', 'pficon-error-circle-o')
+    +pf-message-section(error, 0, 'alert-danger', 'pficon-error-circle-o')
 
     //- Warning
-    +pf-message-section(error, '1', 'alert-warning', 'pficon-warning-triangle-o')
+    +pf-message-section(error, 1, 'alert-warning', 'pficon-warning-triangle-o')
 
     //- Info
-    +pf-message-section(error, '2', 'alert-info', 'pficon-info')
+    +pf-message-section(error, 2, 'alert-info', 'pficon-info')
 
     //- Success
-    +pf-message-section(error, '3', 'alert-success', 'pficon-ok')
+    +pf-message-section(error, 3, 'alert-success', 'pficon-ok')


### PR DESCRIPTION
This removes the multiple error message ability and passes the severity through to the error template

Addresses #90 