### PR TITLE
fix incorrect 'bad document error' when searching for 'TVAR'

### DIFF
--- a/DocumentHelper.js
+++ b/DocumentHelper.js
@@ -92,13 +92,23 @@ class DocumentHelper {
         }
     }
 
-    static extractEnvironmentFromLinkResults(linkDocument) {
+    static extractEnvironmentFromLinkResults(linkDocument, previousQueryKey) {
         try {
             const lnkSet = linkDocument.linksets[0];
-            return {
-                webenv: lnkSet.webenv,
-                querykey: lnkSet.linksetdbhistories[0].querykey
+            if (lnkSet.linksetdbhistories) {
+                return {
+                    webenv: lnkSet.webenv,
+                    querykey: lnkSet.linksetdbhistories[0].querykey
+                };
+            } else {
+                // In this case, the result set of the eLink matches that of the
+                // esearch and a new query-key is not generated
+                return {
+                    webenv: lnkSet.webenv,
+                    querykey: previousQueryKey
+                };
             }
+
         } catch (err) {
             console.error(`error extract env from link result`, err);
             throw new Errors.InvalidDocumentFormatError(err);

--- a/search.js
+++ b/search.js
@@ -40,7 +40,7 @@ let pubMedApi = {
             console.log(`calling esearch for ${searchTerm}...`);
             pmSvc.search(queryTerms, {
                 db: 'pubmed',
-            }).then(results => {
+            }, searchTerm).then(results => {
                 console.log(`calling elink...`);
                 return pmSvc.link({
                     db: 'pmc',
@@ -52,10 +52,12 @@ let pubMedApi = {
                 });
             }).then(linkResults => {
                 console.log(`calling pmc esearch for open access articles...`);
-                return pmSvc.search(['open access[filter]'], {
-                    query_key: linkResults.querykey,
-                    WebEnv: linkResults.webenv
-                });
+                return pmSvc
+                    .search(['open access[filter]'], {
+                            query_key: linkResults.querykey,
+                            WebEnv: linkResults.webenv
+                        },
+                        searchTerm);
             }).then(pmcSearchResults => {
                 //Override the search term
                 pmcSearchResults.searchTerm = searchTerm;

--- a/services/PubMedService.js
+++ b/services/PubMedService.js
@@ -29,7 +29,7 @@ class PubMedService {
      * @param options additional query parameters to be included with the request
      * @return
      */
-    search(queryTerms, options) {
+    search(queryTerms, options, userSearchTerm) {
 
         const searchOptions = {
             uri: `${this.config.baseUri}${this.config.searchPath}`,
@@ -48,7 +48,7 @@ class PubMedService {
                 const searchResult = DocHelper.extractSearchResults(response, queryTerms[0]);
                 console.log(`esearch found ${searchResult.itemsFound} for ${queryTerms[0]}`);
                 if (searchResult.itemsFound === "0") {
-                    throw new Errors.EmptySearchResultError(queryTerms[0]);
+                    throw new Errors.EmptySearchResultError(userSearchTerm || queryTerms[0]);
                 }
                 return searchResult;
             })
@@ -70,7 +70,7 @@ class PubMedService {
             .then(response => {
                 console.log(`processing elink result`);
                 return DocHelper
-                    .extractEnvironmentFromLinkResults(response);
+                    .extractEnvironmentFromLinkResults(response, options.querykey);
             })
     }
 


### PR DESCRIPTION
I suspect that when the eLink returns the same number of results as the initial esearch, we do not get a new query key. The missing query_key in the link result caused the "Bad Document" error. We no longer assume we will get a query key back and use the previous query from the esearch if we don't get one from eLink.