### PR TITLE
return an error for queries that return too many results

### DIFF
--- a/DocumentHelper.js
+++ b/DocumentHelper.js
@@ -150,7 +150,7 @@ class DocumentHelper {
             .catch(err => {
                 // TODO: log the pmid/pmcid of the document
                 console.error(`error extracting abstract for detail document ${err}`, err);
-                throw new Errors.InvalidDocumentFormatError(err);
+                return { abstract: 'error extracting abstract for article ID'};
             });
     }
 

--- a/DocumentHelper.js
+++ b/DocumentHelper.js
@@ -38,8 +38,8 @@ class DocumentHelper {
     static searchErrorResponse(query, error) {
         return {
             searchTerm: query,
-            itemsFound: "0",
-            itemsReturned: "0",
+            itemsFound: 0,
+            itemsReturned: 0,
             error: error.message || 'An unexpected error occurred. Please try again.',
             severity: error.severity || Errors.Severity.Danger
         };
@@ -83,8 +83,8 @@ class DocumentHelper {
                 webenv: searchDocument.esearchresult.webenv,
                 querykey: searchDocument.esearchresult.querykey,
                 searchTerm: query,
-                itemsFound: searchDocument.esearchresult.count,
-                itemsReturned: searchDocument.esearchresult.retmax
+                itemsFound: parseInt(searchDocument.esearchresult.count),
+                itemsReturned: parseInt(searchDocument.esearchresult.retmax)
             };
         } catch (err) {
             console.error(`error extracting search results`, err);

--- a/Errors.js
+++ b/Errors.js
@@ -29,6 +29,12 @@ class EmptySearchResultError extends AppError {
     }
 }
 
+class TooManyResultsError extends AppError {
+    constructor(query, limit) {
+        super(ErrorSeverity.Warn, `Search for "${query}" returned over ${limit} results. Please refine your search`);
+    }
+}
+
 class InvalidQueryStringError extends AppError {
     constructor(query) {
         super(ErrorSeverity.Warn, `"${query}" is not a valid query string`);
@@ -43,6 +49,7 @@ class InvalidDocumentFormatError extends AppError {
 
 module.exports = {
     EmptySearchResultError: EmptySearchResultError,
+    TooManyResultsError: TooManyResultsError,
     InvalidQueryStringError: InvalidQueryStringError,
     InvalidDocumentFormatError: InvalidDocumentFormatError,
     Severity: ErrorSeverity

--- a/config/default.json
+++ b/config/default.json
@@ -1,12 +1,13 @@
 {
   "PubMedService": {
     "baseUri": "https://eutils.ncbi.nlm.nih.gov",
+    "db": "pubmed",
+    "efetchPath": "/entrez/eutils/efetch.fcgi",
+    "elinkPath": "/entrez/eutils/elink.fcgi",
     "searchPath": "/entrez/eutils/esearch.fcgi",
     "summaryPath" : "/entrez/eutils/esummary.fcgi",
-    "elinkPath": "/entrez/eutils/elink.fcgi",
-    "efetchPath": "/entrez/eutils/efetch.fcgi",
-    "db": "pubmed",
-    "searchFilter" : "((randomized controlled trial[pt]) OR (controlled clinical trial[pt]) OR (randomized[tiab] OR randomised[tiab]) OR (placebo[tiab]) OR (drug therapy[sh]) OR (randomly[tiab]) OR (trial[tiab]) OR (groups[tiab])) NOT (animals[mh] NOT humans[mh])"
+    "searchFilter" : "((randomized controlled trial[pt]) OR (controlled clinical trial[pt]) OR (randomized[tiab] OR randomised[tiab]) OR (placebo[tiab]) OR (drug therapy[sh]) OR (randomly[tiab]) OR (trial[tiab]) OR (groups[tiab])) NOT (animals[mh] NOT humans[mh])",
+    "resultsLimit": 10000
   },
 
   "AwsConfig": {

--- a/routes/list.js
+++ b/routes/list.js
@@ -1,6 +1,5 @@
 var express = require("express");
 var router = express.Router();
-var pubMedQuery = require('../search');
 
 router.get('/', (request, response) => {
 

--- a/search.js
+++ b/search.js
@@ -2,6 +2,7 @@
 const config =  require('config');
 const DocumentHelper = require('./DocumentHelper');
 const QueryHelper = require('./QueryHelper');
+const Errors = require('./Errors');
 
 const demoSvc = function() {
     const awsConfig = config.get('AwsConfig')
@@ -16,7 +17,7 @@ const pmSvc = function() {
 }();
 
 let errorOf = (description) => {
-  return {error: description};
+  return {error: description, severity: Errors.Severity.Danger};
 };
 
 let pubMedApi = {

--- a/services/PubMedService.js
+++ b/services/PubMedService.js
@@ -31,6 +31,8 @@ class PubMedService {
      */
     search(queryTerms, options, userSearchTerm) {
 
+        userSearchTerm = userSearchTerm || queryTerms[0];
+
         const searchOptions = {
             uri: `${this.config.baseUri}${this.config.searchPath}`,
             json: true,
@@ -47,8 +49,11 @@ class PubMedService {
             .then(response => {
                 const searchResult = DocHelper.extractSearchResults(response, queryTerms[0]);
                 console.log(`esearch found ${searchResult.itemsFound} for ${queryTerms[0]}`);
-                if (searchResult.itemsFound === "0") {
-                    throw new Errors.EmptySearchResultError(userSearchTerm || queryTerms[0]);
+                if (searchResult.itemsFound === 0) {
+                    throw new Errors.EmptySearchResultError(userSearchTerm);
+                }
+                if (searchResult.itemsFound > this.config.resultsLimit) {
+                    throw new Errors.TooManyResultsError(userSearchTerm, this.config.resultsLimit);
                 }
                 return searchResult;
             })

--- a/services/PubMedService.js
+++ b/services/PubMedService.js
@@ -27,11 +27,16 @@ class PubMedService {
      *
      * @param queryTerms And Array of terms to query
      * @param options additional query parameters to be included with the request
+     * @param userSearchTerm the search term to use in error messages returned to the user
      * @return
      */
     search(queryTerms, options, userSearchTerm) {
 
         userSearchTerm = userSearchTerm || queryTerms[0];
+
+        if (QueryHelper.isEmptyTerm(userSearchTerm)) {
+            return Promise.reject(new Errors.InvalidQueryStringError(userSearchTerm));
+        }
 
         const searchOptions = {
             uri: `${this.config.baseUri}${this.config.searchPath}`,

--- a/test/ConfigurationSpec.js
+++ b/test/ConfigurationSpec.js
@@ -6,7 +6,7 @@ const pubMedConfig = config.get('PubMedService');
 
 describe('Configuration', function() {
 
-    describe('PubMedService', function () {
+    describe('PubMedService Configuration', function () {
         it('defines a valid baseUri', function () {
             assert.equal(pubMedConfig.baseUri,
                 "https://eutils.ncbi.nlm.nih.gov");

--- a/test/DocumentHelperSpec.js
+++ b/test/DocumentHelperSpec.js
@@ -97,7 +97,6 @@ describe('DocumentHelper', function () {
             var lastIdx = -1;
             sec1Sentences.forEach(sentence => {
                 let idx = texts.indexOf(sentence);
-                console.log(`checking idx ${idx}`);
                 assert.strictEqual(idx > lastIdx, true);
                 lastIdx = idx;
             });
@@ -106,7 +105,6 @@ describe('DocumentHelper', function () {
             var lastIdx = -1;
             sec2Sentences.forEach(sentence => {
                 let idx = texts.indexOf(sentence);
-                console.log(`checking idx ${idx}`);
                 assert.strictEqual(idx > lastIdx, true);
                 lastIdx = idx;
             });

--- a/test/PubMedServiceSpec.js
+++ b/test/PubMedServiceSpec.js
@@ -68,7 +68,7 @@ describe('PubMedService', function () {
 
             mockSearchResponse(searchTerm, queryOptions, pubMedSearchResponse);
 
-            const response = pmSvc.search([searchTerm], queryOptions);
+            const response = pmSvc.search([searchTerm], queryOptions, searchTerm);
 
             response.then(x => {
                 assert.fail(x, "", "expected failed Promise");
@@ -79,7 +79,7 @@ describe('PubMedService', function () {
             });
         });
 
-        it('returns a TooManyResultsError for more than `resultsLimit items returned', function () {
+        it('returns a TooManyResultsError for more than `resultsLimit` items returned', function () {
             const pubMedSearchResponse = require('./data/search/pubmed_search_too_many_results.json');
             const searchTerm = 'zika';
             const queryOptions = {
@@ -88,7 +88,7 @@ describe('PubMedService', function () {
 
             mockSearchResponse(searchTerm, queryOptions, pubMedSearchResponse);
 
-            const response = pmSvc.search([searchTerm], queryOptions);
+            const response = pmSvc.search([searchTerm], queryOptions, searchTerm);
 
             return response.then(x => {
                 assert.fail(x, "", "expected failed Promise");
@@ -97,6 +97,44 @@ describe('PubMedService', function () {
                     'TooManyResultsError');;
             });
         });
+
+        it('returns InvalidQueryStringError for an empty query string', function () {
+            const searchTerm = '';
+            const response = pmSvc.search([searchTerm], {});
+
+            return response.then(x => {
+                assert.fail(x, "", "expected failed Promise");
+            }).catch(err => {
+                assert.strictEqual(err.constructor.name,
+                    'InvalidQueryStringError');
+            });
+        });
+
+
+        it('returns InvalidQueryStringError for an undefined query string', function () {
+            const searchTerm = null;
+            const response = pmSvc.search([searchTerm], {});
+
+            return response.then(x => {
+                assert.fail(x, "", "expected failed Promise");
+            }).catch(err => {
+                assert.strictEqual(err.constructor.name,
+                    'InvalidQueryStringError');
+            });
+        });
+
+        it('returns InvalidQueryStringError for an whitespace query string', function () {
+            const searchTerm = '       ';
+            const response = pmSvc.search([searchTerm], {});
+
+            return response.then(x => {
+                assert.fail(x, "", "expected failed Promise");
+            }).catch(err => {
+                assert.strictEqual(err.constructor.name,
+                    'InvalidQueryStringError');
+            });
+        });
+
     });
 
     describe('.fetchSummary', function () {

--- a/test/data/search/pubmed_search_too_many_results.json
+++ b/test/data/search/pubmed_search_too_many_results.json
@@ -1,0 +1,173 @@
+{
+  "header": {
+    "type": "esearch",
+    "version": "0.3"
+  },
+  "esearchresult": {
+    "count": "89324",
+    "retmax": "20",
+    "retstart": "0",
+    "querykey": "1",
+    "webenv": "NCID_1_41963603_130.14.18.34_9001_1523130080_1791019099_0MetA0_S_MegaStore",
+    "idlist": [],
+    "translationset": [
+      {
+        "from": "guillain barre syndrome",
+        "to": "\"guillain-barre syndrome\"[MeSH Terms] OR (\"guillain-barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain-barre syndrome\"[All Fields] OR (\"guillain\"[All Fields] AND \"barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain barre syndrome\"[All Fields]"
+      },
+      {
+        "from": "drug therapy[sh]",
+        "to": "\"drug therapy\"[Subheading]"
+      },
+      {
+        "from": "animals[mh]",
+        "to": "\"animals\"[MeSH Terms]"
+      },
+      {
+        "from": "humans[mh]",
+        "to": "\"humans\"[MeSH Terms]"
+      }
+    ],
+    "translationstack": [
+      {
+        "term": "\"guillain-barre syndrome\"[MeSH Terms]",
+        "field": "MeSH Terms",
+        "count": "4447",
+        "explode": "Y"
+      },
+      {
+        "term": "\"guillain-barre\"[All Fields]",
+        "field": "All Fields",
+        "count": "9065",
+        "explode": "N"
+      },
+      {
+        "term": "\"syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "1066274",
+        "explode": "N"
+      },
+      "AND",
+      "GROUP",
+      "OR",
+      {
+        "term": "\"guillain-barre syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "8727",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "\"guillain\"[All Fields]",
+        "field": "All Fields",
+        "count": "9331",
+        "explode": "N"
+      },
+      {
+        "term": "\"barre\"[All Fields]",
+        "field": "All Fields",
+        "count": "11161",
+        "explode": "N"
+      },
+      "AND",
+      {
+        "term": "\"syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "1066274",
+        "explode": "N"
+      },
+      "AND",
+      "GROUP",
+      "OR",
+      {
+        "term": "\"guillain barre syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "8727",
+        "explode": "N"
+      },
+      "OR",
+      "GROUP",
+      {
+        "term": "randomized controlled trial[pt]",
+        "field": "pt",
+        "count": "457553",
+        "explode": "Y"
+      },
+      {
+        "term": "controlled clinical trial[pt]",
+        "field": "pt",
+        "count": "545005",
+        "explode": "Y"
+      },
+      "OR",
+      {
+        "term": "randomized[tiab]",
+        "field": "tiab",
+        "count": "438872",
+        "explode": "N"
+      },
+      {
+        "term": "randomised[tiab]",
+        "field": "tiab",
+        "count": "88035",
+        "explode": "N"
+      },
+      "OR",
+      "GROUP",
+      "OR",
+      {
+        "term": "placebo[tiab]",
+        "field": "tiab",
+        "count": "192700",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "\"drug therapy\"[Subheading]",
+        "field": "Subheading",
+        "count": "2005762",
+        "explode": "Y"
+      },
+      "OR",
+      {
+        "term": "randomly[tiab]",
+        "field": "tiab",
+        "count": "288237",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "trial[tiab]",
+        "field": "tiab",
+        "count": "500412",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "groups[tiab]",
+        "field": "tiab",
+        "count": "1805593",
+        "explode": "N"
+      },
+      "OR",
+      "GROUP",
+      "AND",
+      {
+        "term": "\"animals\"[MeSH Terms]",
+        "field": "MeSH Terms",
+        "count": "21422923",
+        "explode": "Y"
+      },
+      {
+        "term": "\"humans\"[MeSH Terms]",
+        "field": "MeSH Terms",
+        "count": "16982228",
+        "explode": "Y"
+      },
+      "NOT",
+      "GROUP",
+      "NOT"
+    ],
+    "querytranslation": "(\"guillain-barre syndrome\"[MeSH Terms] OR (\"guillain-barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain-barre syndrome\"[All Fields] OR (\"guillain\"[All Fields] AND \"barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain barre syndrome\"[All Fields]) AND (randomized controlled trial[pt] OR controlled clinical trial[pt] OR (randomized[tiab] OR randomised[tiab]) OR placebo[tiab] OR \"drug therapy\"[Subheading] OR randomly[tiab] OR trial[tiab] OR groups[tiab]) NOT (\"animals\"[MeSH Terms] NOT \"humans\"[MeSH Terms])"
+  }
+}

--- a/test/data/search/pubmed_search_zero_results.json
+++ b/test/data/search/pubmed_search_zero_results.json
@@ -1,0 +1,173 @@
+{
+  "header": {
+    "type": "esearch",
+    "version": "0.3"
+  },
+  "esearchresult": {
+    "count": "0",
+    "retmax": "20",
+    "retstart": "0",
+    "querykey": "1",
+    "webenv": "NCID_1_41963603_130.14.18.34_9001_1523130080_1791019099_0MetA0_S_MegaStore",
+    "idlist": [],
+    "translationset": [
+      {
+        "from": "guillain barre syndrome",
+        "to": "\"guillain-barre syndrome\"[MeSH Terms] OR (\"guillain-barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain-barre syndrome\"[All Fields] OR (\"guillain\"[All Fields] AND \"barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain barre syndrome\"[All Fields]"
+      },
+      {
+        "from": "drug therapy[sh]",
+        "to": "\"drug therapy\"[Subheading]"
+      },
+      {
+        "from": "animals[mh]",
+        "to": "\"animals\"[MeSH Terms]"
+      },
+      {
+        "from": "humans[mh]",
+        "to": "\"humans\"[MeSH Terms]"
+      }
+    ],
+    "translationstack": [
+      {
+        "term": "\"guillain-barre syndrome\"[MeSH Terms]",
+        "field": "MeSH Terms",
+        "count": "4447",
+        "explode": "Y"
+      },
+      {
+        "term": "\"guillain-barre\"[All Fields]",
+        "field": "All Fields",
+        "count": "9065",
+        "explode": "N"
+      },
+      {
+        "term": "\"syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "1066274",
+        "explode": "N"
+      },
+      "AND",
+      "GROUP",
+      "OR",
+      {
+        "term": "\"guillain-barre syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "8727",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "\"guillain\"[All Fields]",
+        "field": "All Fields",
+        "count": "9331",
+        "explode": "N"
+      },
+      {
+        "term": "\"barre\"[All Fields]",
+        "field": "All Fields",
+        "count": "11161",
+        "explode": "N"
+      },
+      "AND",
+      {
+        "term": "\"syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "1066274",
+        "explode": "N"
+      },
+      "AND",
+      "GROUP",
+      "OR",
+      {
+        "term": "\"guillain barre syndrome\"[All Fields]",
+        "field": "All Fields",
+        "count": "8727",
+        "explode": "N"
+      },
+      "OR",
+      "GROUP",
+      {
+        "term": "randomized controlled trial[pt]",
+        "field": "pt",
+        "count": "457553",
+        "explode": "Y"
+      },
+      {
+        "term": "controlled clinical trial[pt]",
+        "field": "pt",
+        "count": "545005",
+        "explode": "Y"
+      },
+      "OR",
+      {
+        "term": "randomized[tiab]",
+        "field": "tiab",
+        "count": "438872",
+        "explode": "N"
+      },
+      {
+        "term": "randomised[tiab]",
+        "field": "tiab",
+        "count": "88035",
+        "explode": "N"
+      },
+      "OR",
+      "GROUP",
+      "OR",
+      {
+        "term": "placebo[tiab]",
+        "field": "tiab",
+        "count": "192700",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "\"drug therapy\"[Subheading]",
+        "field": "Subheading",
+        "count": "2005762",
+        "explode": "Y"
+      },
+      "OR",
+      {
+        "term": "randomly[tiab]",
+        "field": "tiab",
+        "count": "288237",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "trial[tiab]",
+        "field": "tiab",
+        "count": "500412",
+        "explode": "N"
+      },
+      "OR",
+      {
+        "term": "groups[tiab]",
+        "field": "tiab",
+        "count": "1805593",
+        "explode": "N"
+      },
+      "OR",
+      "GROUP",
+      "AND",
+      {
+        "term": "\"animals\"[MeSH Terms]",
+        "field": "MeSH Terms",
+        "count": "21422923",
+        "explode": "Y"
+      },
+      {
+        "term": "\"humans\"[MeSH Terms]",
+        "field": "MeSH Terms",
+        "count": "16982228",
+        "explode": "Y"
+      },
+      "NOT",
+      "GROUP",
+      "NOT"
+    ],
+    "querytranslation": "(\"guillain-barre syndrome\"[MeSH Terms] OR (\"guillain-barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain-barre syndrome\"[All Fields] OR (\"guillain\"[All Fields] AND \"barre\"[All Fields] AND \"syndrome\"[All Fields]) OR \"guillain barre syndrome\"[All Fields]) AND (randomized controlled trial[pt] OR controlled clinical trial[pt] OR (randomized[tiab] OR randomised[tiab]) OR placebo[tiab] OR \"drug therapy\"[Subheading] OR randomly[tiab] OR trial[tiab] OR groups[tiab]) NOT (\"animals\"[MeSH Terms] NOT \"humans\"[MeSH Terms])"
+  }
+}


### PR DESCRIPTION
The maximum number of results for a query will be limited to 10K.