### PR TITLE
improve error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,12 @@
 // app.js
-var express = require('express');
-var path = require('path');
-var bodyparser = require('body-parser');
-var list = require('./routes/list');
-var results = require('./routes/results');
-var detail = require('./routes/detail');
-var app = express();
+const express = require('express');
+const path = require('path');
+const bodyparser = require('body-parser');
+const list = require('./routes/list');
+const results = require('./routes/results');
+const detail = require('./routes/detail');
+const app = express();
+const Errors = require('./Errors');
 
 require('dotenv').config();
 
@@ -43,6 +44,20 @@ app.use('/detail', detail);
 app.use((request, response, next) => {
     response.status(404);
     response.send('File could not be found');
+});
+
+
+app.use((err, req, res, next) => {
+    console.error(`in global error handler handling ${err.stack}`);
+    const errMsg = {
+        error: {
+            msg: err.message || 'An internal error occurred. Please try again',
+            severity: err.severity || Errors.Severity.Danger
+        }
+    };
+
+    const template = req.xhr ? 'messages' : 'results';
+    res.status(500).render(template, errMsg);
 });
 
 module.exports = app;

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
   "PubMedService": {
+    "defaultDb": "pubmed",
     "baseUri": "https://eutils.ncbi.nlm.nih.gov",
-    "db": "pubmed",
     "efetchPath": "/entrez/eutils/efetch.fcgi",
     "elinkPath": "/entrez/eutils/elink.fcgi",
     "searchPath": "/entrez/eutils/esearch.fcgi",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,6 +1616,16 @@
         "vary": "1.1.2"
       }
     },
+    "express-promise-router": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-3.0.2.tgz",
+      "integrity": "sha1-LPDd6NkDYFBxtSJ4pt0a4P8Ak+I=",
+      "requires": {
+        "is-promise": "2.1.0",
+        "lodash.flattendeep": "4.4.0",
+        "methods": "1.1.2"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -3067,6 +3077,11 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.isarguments": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "config": "^1.30.0",
     "dotenv": "^5.0.1",
     "express": "^4.16.3",
+    "express-promise-router": "^3.0.2",
     "gulp": "^3.9.1",
     "gulp-less": "^4.0.0",
     "gulp-plumber": "^1.2.0",

--- a/routes/detail.js
+++ b/routes/detail.js
@@ -1,14 +1,15 @@
-let express = require("express");
-let router = express.Router();
-let pubMedQuery = require('../search');
+const router = require('express-promise-router')();
+const pubSvc = require('../search');
 
-router.get('/:pmid', (request, response) => {
+router.get('/:pmid', (request, response, next) => {
 
     let pmid = request.params["pmid"]
 
-    pubMedQuery.fetchResultDetail(pmid, (details) => {
-        response.render('abstractSections', {"data": details});
-    });
+    return pubSvc
+        .fetchResultDetail(pmid)
+        .then(details => {
+            response.render('abstractSections', {"data": details});
+        });
 });
 
 module.exports = router;

--- a/routes/list.js
+++ b/routes/list.js
@@ -1,5 +1,4 @@
-var express = require("express");
-var router = express.Router();
+const router = require('express-promise-router')();
 
 router.get('/', (request, response) => {
 

--- a/routes/results.js
+++ b/routes/results.js
@@ -1,47 +1,32 @@
-var express = require("express");
-var router = express.Router();
-var pubMedQuery = require('../search');
+const router = require('express-promise-router')();
+const pubSvc = require('../search');
 
 const rowRequestSize = 20;
 
-router.get('/', (request, response) => {
+router.get('/', (request, response, next) => {
 
-    // search PubMed for results matching the search terms
-    pubMedQuery.search(request.query, (queryResult) => {
-
-        if (queryResult.error || queryResult.itemsFound === 0) {
-            console.log(`results.js error or empty: ${JSON.stringify(queryResult)}`);
-            const errResponse = {
-                error: {
-                    msg: queryResult.error,
-                    severity: queryResult.severity
-                }
-            };
-
-            response.render('results', errResponse);
-        } else {
-            // Get summaries for the first set of result rows
-            console.log(`results.js calling getSummaries ${JSON.stringify(queryResult)}`);
-            pubMedQuery.getSummaries(queryResult.webenv, queryResult.querykey, 0, rowRequestSize, (results) => {
-
-                console.log(`results.js rending template ${JSON.stringify(results)}`);
-                // Render the 'results' view using query results
-                response.render('results', {"results": results,
-                                            "qryResult": queryResult});
-            });
-        }
-    });
+    return pubSvc.search(request.query)
+        .then(qr => {
+            return pubSvc
+                .getSummaries(qr.webenv, qr.querykey, 0, rowRequestSize)
+                .then(results => {
+                    response.render('results', {
+                        results: results,
+                        qryResult: qr
+                    });
+                });
+        });
 });
 
-router.get('/:webenv/:querykey', function(req, res, next) {
+router.get('/:webenv/:querykey', (req, res, next) => {
 
     // Get summaries for result rows
-    pubMedQuery.getSummaries(req.params.webenv, req.params.querykey, req.query.start, rowRequestSize, (results) => {
-
-        // Render the 'list' view using query results, if any
-        res.render('resultRows', { "results": results });
-    });
-
+    return pubSvc
+        .getSummaries(req.params.webenv, req.params.querykey, req.query.start, rowRequestSize)
+        .then(results => {
+            // Render the 'list' view using query results, if any
+            res.render('resultRows', { "results": results });
+        });
 });
 
 module.exports = router;

--- a/services/PubMedService.js
+++ b/services/PubMedService.js
@@ -53,8 +53,8 @@ class PubMedService {
             // E-search
             .client(searchOptions)
             .then(response => {
-                const searchResult = DocHelper.extractSearchResults(response, queryTerms[0]);
-                console.log(`esearch found ${searchResult.itemsFound} for ${queryTerms[0]}`);
+                const searchResult = DocHelper.extractSearchResults(response, userSearchTerm);
+                console.log(`esearch found ${searchResult.itemsFound} for ${userSearchTerm}`);
                 if (searchResult.itemsFound === 0) {
                     throw new Errors.EmptySearchResultError(userSearchTerm);
                 }
@@ -82,7 +82,7 @@ class PubMedService {
             .then(response => {
                 console.log(`processing elink result`);
                 return DocHelper
-                    .extractEnvironmentFromLinkResults(response, options.querykey);
+                    .extractEnvironmentFromLinkResults(response, options.query_key);
             })
     }
 
@@ -99,7 +99,7 @@ class PubMedService {
             timeout: this.config.defaultTimeout,
             qs: {
                 // TODO: use the API key in the query parameters
-                db: this.config.db,
+                db: options.db || this.config.defaultDb,
                 WebEnv: environment.webenv,
                 query_key: environment.querykey,
                 retstart: options.start || 0,

--- a/test/ConfigurationSpec.js
+++ b/test/ConfigurationSpec.js
@@ -12,8 +12,8 @@ describe('Configuration', function() {
                 "https://eutils.ncbi.nlm.nih.gov");
         });
 
-        it('defines a database', function (done) {
-            if(pubMedConfig.db) {
+        it('defines a default database', function (done) {
+            if(pubMedConfig.defaultDb) {
                 done();
             } else {
                 done(new Error("dd not defined for PMS configuration"));

--- a/test/PubMedServiceSpec.js
+++ b/test/PubMedServiceSpec.js
@@ -147,6 +147,7 @@ describe('PubMedService', function () {
             };
 
             const options = {
+                db: 'pmc',
                 start: 0,
                 max: 3,
             };
@@ -154,7 +155,7 @@ describe('PubMedService', function () {
             const pmMock = nock(`${pubMedConfig.baseUri}`)
                 .get(`${pubMedConfig.summaryPath}`)
                 .query({
-                    db: `${pubMedConfig.db}`,
+                    db: 'pmc',
                     retmax: options.max,
                     retstart: options.start,
                     WebEnv: environment.webenv,


### PR DESCRIPTION
This change installs a global error handler for express to recover errors rather than trying to recover errors in every code path of the main business logic. A couple of bugs were also fixed:

- Pass `"pmc"` as the database to the second `esearch` we perform
- The `query_key` passed to elink in some cases was `null` because the wrong variable name was used