### PR TITLE
Handle undefined sentences from DynamoDB

### DIFF
--- a/DocumentHelper.js
+++ b/DocumentHelper.js
@@ -167,7 +167,7 @@ class DocumentHelper {
     }
 
     static groupSentencesBySection(sentences) {
-        const groupedSentences = sentences
+        const groupedSentences = (sentences || [])
             .reduce((acc, s) => {
                 acc[s.section] = (acc[s.section] || []);
                 acc[s.section].push(s.text);

--- a/services/DemographicsService.js
+++ b/services/DemographicsService.js
@@ -67,7 +67,7 @@ class DemographicsService {
                 }, {});
             })
             .catch( err => {
-                console.log(`dynamo batchGet error: ${err}`);
+                console.log(`dynamo batchGet error: ${err.stack}`);
                 throw new Errors.AppError(Errors.Severity.Danger, 'Internal error. Please try again.');
             });
     }

--- a/test/DocumentHelperSpec.js
+++ b/test/DocumentHelperSpec.js
@@ -56,6 +56,11 @@ describe('DocumentHelper', function () {
 
     describe('.groupSentencesBySection', function () {
 
+        it('handles undefined arrays', function () {
+            const grouped = DocHelper.groupSentencesBySection(null);
+            assert.strictEqual(grouped.length, 0);
+        });
+
         it('handles empty arrays', function () {
             const grouped = DocHelper.groupSentencesBySection([]);
             assert.strictEqual(grouped.length, 0);


### PR DESCRIPTION
It seems with a recent change sentences may come back from Dynamo as undefined. This fix addresses this issue

Addresses #105