### PR TITLE
Use optional API KEY in NCBI API calls

### DIFF
--- a/QueryHelper.js
+++ b/QueryHelper.js
@@ -43,6 +43,12 @@ class QueryHelper {
             .slice(1)
             .reduce((acc, term) => `${acc} AND (${term})`, `(${validTerms[0]})`)
     }
+
+
+    static mergeQueryOptions(optionsArray) {
+        return (optionsArray || [])
+            .reduce((acc, opt) => Object.assign(acc, opt), {})
+    }
 }
 
 module.exports = QueryHelper;

--- a/config/default.json
+++ b/config/default.json
@@ -10,7 +10,8 @@
     "resultsLimit": 10000,
     "elinkTimeout": 15000,
     "esearchTimeout": 5000,
-    "defaultTimeout": 3000
+    "defaultTimeout": 3000,
+    "queryOptions": {}
   },
 
   "AwsConfig": {

--- a/services/PubMedService.js
+++ b/services/PubMedService.js
@@ -18,6 +18,7 @@ class PubMedService {
     constructor(config) {
         this.client = http;
         this.config = config;
+        this.baseQueryOptions = this.config.queryOptions;
     }
 
     /**
@@ -42,11 +43,15 @@ class PubMedService {
             uri: `${this.config.baseUri}${this.config.searchPath}`,
             json: true,
             timeout: this.config.esearchTimeout,
-            qs: Object.assign({
-                term: QueryHelper.combineSearchTerms(queryTerms),
-                retmode: 'json',
-                usehistory: 'y',
-            }, options)
+            qs: QueryHelper.mergeQueryOptions([
+                this.baseQueryOptions,
+                {
+                    term: QueryHelper.combineSearchTerms(queryTerms),
+                    retmode: 'json',
+                    usehistory: 'y',
+                },
+                options
+            ])
         };
 
         return this
@@ -71,10 +76,14 @@ class PubMedService {
             uri: `${this.config.baseUri}${this.config.elinkPath}`,
             json: true,
             timeout: this.config.elinkTimeout,
-            qs: Object.assign({
-                retmode: 'json',
-                usehistory: 'y',
-            }, options)
+            qs: QueryHelper.mergeQueryOptions([
+                this.baseQueryOptions,
+                {
+                    retmode: 'json',
+                    usehistory: 'y',
+                },
+                options
+            ])
         };
 
         return this
@@ -97,15 +106,17 @@ class PubMedService {
             uri: `${this.config.baseUri}${this.config.summaryPath}`,
             json: true,
             timeout: this.config.defaultTimeout,
-            qs: {
-                // TODO: use the API key in the query parameters
-                db: options.db || this.config.defaultDb,
-                WebEnv: environment.webenv,
-                query_key: environment.querykey,
-                retstart: options.start || 0,
-                retmax: options.max || 20, // TODO: use config value here
-                retmode: "json"
-            }
+            qs: QueryHelper.mergeQueryOptions([
+                this.baseQueryOptions,
+                {
+                    // TODO: use the API key in the query parameters
+                    db: options.db || this.config.defaultDb,
+                    WebEnv: environment.webenv,
+                    query_key: environment.querykey,
+                    retstart: options.start || 0,
+                    retmax: options.max || 20, // TODO: use config value here
+                    retmode: "json"
+                }])
         };
 
         return this
@@ -128,10 +139,14 @@ class PubMedService {
             uri: `${this.config.baseUri}${this.config.efetchPath}`,
             json: true,
             timeout: this.config.defaultTimeout,
-            qs: Object.assign({
-                retmode: 'xml',
-                id: articleId
-            }, options)
+            qs: QueryHelper.mergeQueryOptions([
+                this.baseQueryOptions,
+                {
+                    retmode: 'xml',
+                    id: articleId
+                },
+                options
+            ])
         };
 
         console.log(`fetching details for ${articleId}`);

--- a/test/QueryHelperSpec.js
+++ b/test/QueryHelperSpec.js
@@ -80,5 +80,94 @@ describe('QueryTermHelper', function () {
         });
 
     });
+
+    describe('.mergeQueryOptions', function () {
+
+        it('returns an empty object for undefined array', function () {
+            const merged = QueryHelper.mergeQueryOptions(null);
+            const mergedString = JSON.stringify(merged);
+            assert.strictEqual(mergedString, JSON.stringify({}));
+        });
+
+        it('returns an empty object for empty array', function () {
+            const merged = QueryHelper.mergeQueryOptions([]);
+            const mergedString = JSON.stringify(merged);
+            assert.strictEqual(mergedString, JSON.stringify({}));
+        });
+
+        it('returns a single object unchanged', function () {
+            const baseOptions = {
+                retmax: 15,
+                api_key: "hello"
+            };
+            const merged = QueryHelper.mergeQueryOptions([baseOptions]);
+            assert.deepStrictEqual(merged, baseOptions)
+        });
+
+        it('combines all provided fields into the final object', function () {
+            const baseOptions = {
+                api_key: "hello"
+            };
+
+            const callOptions = {
+                retmax: 99
+            };
+
+            const expectedCombined = {
+                api_key: "hello",
+                retmax: 99
+            };
+
+            const merged = QueryHelper.mergeQueryOptions([baseOptions, callOptions]);
+            assert.deepStrictEqual(merged, expectedCombined);
+        });
+
+        it('combines all provided fields into the final object for multiple objects', function () {
+            const baseOptions = {
+                api_key: "hello"
+            };
+
+            const callOptions = {
+                retstart: 0
+            };
+
+            const serviceOptions = {
+                retmax: 99
+            };
+
+            const expectedCombined = {
+                api_key: "hello",
+                retmax: 99,
+                retstart: 0
+            };
+
+            const merged = QueryHelper.mergeQueryOptions([baseOptions, callOptions, serviceOptions]);
+            assert.deepStrictEqual(merged, expectedCombined);
+        });
+
+        it('overrides fields defined in later objects', function () {
+            const baseOptions = {
+                api_key: "hello"
+            };
+
+            const callOptions = {
+                retstart: 0,
+                retmax: 99
+            };
+
+            const overrideOptions = {
+                retstart: 20
+            };
+
+            const expectedCombined = {
+                api_key: "hello",
+                retmax: 99,
+                retstart: 20
+            };
+
+            const merged = QueryHelper.mergeQueryOptions([baseOptions, callOptions, overrideOptions]);
+            assert.deepStrictEqual(merged, expectedCombined);
+        });
+    });
 });
 


### PR DESCRIPTION
Allows optional use of an API KEY. The API KEY should be put in `local.json` in the deployed machined under the `config` folder. The example below shows how to provide the API KEY for the application to use in service calls:

`<repo-root>/config/local.json`:
```json
{
  "PubMedService": {
    "queryOptions": {
      "api_key": "<your-api-key-here>"
    }
  }
}
```